### PR TITLE
refactor(styles): change method of applying border effect

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -32,7 +32,7 @@
 
   &:active {
     border-color: var(--auro-color-border-active-on-light);
-    outline: 1px solid var(--auro-color-border-active-on-light);
+    box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-light);
   }
 }
 
@@ -139,16 +139,16 @@
 
   .trigger {
     border-color: var(--auro-color-border-error-on-light);
-    outline: 1px solid var(--auro-color-alert-error-on-light);
+    box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-light);
 
     &:focus-within {
       border-color: var(--auro-color-border-active-on-light);
-      outline: none;
+      box-shadow: none;
     }
 
     &:active {
       border-color: var(--auro-color-border-active-on-light);
-      outline: 1px solid var(--auro-color-border-active-on-light);
+      box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-light);
     }
   }
 }
@@ -162,16 +162,16 @@
 :host([bordered][error]) {
   .trigger {
     border-color: var(--auro-color-border-error-on-light);
-    outline: 1px solid var(--auro-color-alert-error-on-light);
+    box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-light);
 
     &:focus-within {
       border-color: var(--auro-color-border-active-on-light);
-      outline: none;
+      box-shadow: none;
     }
 
     &:active {
       border-color: var(--auro-color-border-active-on-light);
-      outline: 1px solid var(--auro-color-border-active-on-light);
+      box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-light);
     }
   }
 }
@@ -186,12 +186,12 @@
 
     &:focus-within {
       border-color: var(--auro-color-border-active-on-dark);
-      outline: none;
+      box-shadow: none;
     }
 
     &:active {
       border-color: var(--auro-color-border-active-on-dark);
-      outline: 1px solid var(--auro-color-border-active-on-dark);
+      box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-dark);
     }
   }
 
@@ -222,16 +222,16 @@
 
   .trigger {
     border-color: var(--auro-color-border-error-on-dark);
-    outline: 1px solid var(--auro-color-border-error-on-dark);
+    box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-dark);
 
     &:focus-within {
       border-color: var(--auro-color-border-active-on-dark);
-      outline: none;
+      box-shadow: none;
     }
 
     &:active {
       border-color: var(--auro-color-border-active-on-dark);
-      outline: 1px solid var(--auro-color-border-active-on-dark);
+      box-shadow: inset 0 0 0 1px var(--auro-color-border-active-on-dark);
     }
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #50

## Summary:

The previous CSS outline method of highlighting the border in certain states would not work with the rounded border effect in Safari. This changes to use box-shadow which does correctly work in Safari.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
