### PR TITLE
fix(toggle): prevent default key behavior when toggle on dropdown

### DIFF
--- a/src/auro-dropdown.js
+++ b/src/auro-dropdown.js
@@ -146,6 +146,7 @@ class AuroDropdown extends LitElement {
       const key = event.key.toLowerCase();
 
       if (key === ' ' || key === 'enter') {
+        event.preventDefault();
         toggleDropdown; /* eslint-disable-line no-unused-expressions */
       }
     };


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #91

## Summary:

Prevent default key behavior for `space` and `enter` key on dropdowns with the toggle attribute. We already did this for dropdowns without toggle.

This is necessary to make those keys open the bib rather than take the default browser client behavior for those two keys.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
