### PR TITLE
refactor(template): improve a11y within bib content

### DIFF
--- a/src/auro-dropdown.js
+++ b/src/auro-dropdown.js
@@ -159,6 +159,7 @@ class AuroDropdown extends LitElement {
     }
 
     this.trigger.addEventListener('keydown', hideByKeyboard);
+    this.popover.addEventListener('keydown', hideByKeyboard);
   }
 
   /**
@@ -218,9 +219,6 @@ class AuroDropdown extends LitElement {
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     return html`
-      <div id="popover" class="popover" aria-live="polite" style=${`min-width: ${this.dropdownWidth}px;`}>
-        <slot role="tooltip"></slot>
-      </div>
       <div
         id="trigger"
         class="trigger"
@@ -246,6 +244,9 @@ class AuroDropdown extends LitElement {
       </div>
       <div class="helpText">
         <slot name="helpText"></slot>
+      </div>
+      <div id="popover" class="popover" aria-live="polite" style=${`min-width: ${this.dropdownWidth}px;`}>
+        <slot role="tooltip"></slot>
       </div>
     `;
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #89

## Summary:

Bib content is moved to after the trigger in the DOM so that it is in the normal tabindex order. Otherwise, after opening the bib, you had to shift+tab to go to the bib content.

Also, added the ability to close the bib by hitting the the `esc` key while focus is inside the bib content.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
