### PR TITLE
fix(event): only fire triggerClick event with space or enter key #135

### DIFF
--- a/src/auro-dropdown.js
+++ b/src/auro-dropdown.js
@@ -231,7 +231,13 @@ class AuroDropdown extends LitElement {
       }
     } else {
       this.trigger.addEventListener('click', notifyTriggerClicked);
-      this.trigger.addEventListener('keydown', notifyTriggerClicked);
+      this.trigger.addEventListener('keydown', (evt) => {
+        const key = evt.key.toLowerCase();
+
+        if (key === ' ' || key === 'enter') {
+          notifyTriggerClicked();
+        }
+      });
     }
 
     this.trigger.addEventListener('keydown', hideByKeyboard);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #135 (issue, if applicable)

## Summary:

No longer fires the `auroDropdown-triggerClick` event on all key events. Now it only fires on space and enter key.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
