### PR TITLE
fix(a11y): aria-expanded / aria-labelledby / aria-controls attributes

### DIFF
--- a/src/auro-dropdown.js
+++ b/src/auro-dropdown.js
@@ -169,10 +169,12 @@ class AuroDropdown extends LitElement {
 
   firstUpdated() {
     this.fixWidth();
-    this.setAttribute('aria-expanded', this.isPopoverVisible);
 
     this.trigger = this.shadowRoot.querySelector(`#trigger`);
+    this.trigger.setAttribute('aria-expanded', this.isPopoverVisible);
+
     this.triggerChevron = this.shadowRoot.querySelector(`#showStateIcon`);
+
     this.popover = this.shadowRoot.querySelector('#popover');
     this.popper = new Popover(this.trigger, this.popover, this.placement);
 
@@ -352,7 +354,7 @@ class AuroDropdown extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has('isPopoverVisible')) {
-      this.setAttribute('aria-expanded', this.isPopoverVisible);
+      this.trigger.setAttribute('aria-expanded', this.isPopoverVisible);
       if (this.isPopoverVisible) {
         document.addEventListener('click', document.expandedAuroDropdown.outsideClick);
       } else if (document.expandedAuroDropdown) {
@@ -369,13 +371,15 @@ class AuroDropdown extends LitElement {
         class="trigger"
         part="trigger"
         role="button"
+        aria-labelledby="triggerLabel"
+        aria-controls="popover"
         data-trigger-placement="${this.placement}"
         tabindex="${this.tabIndex}">
         <div class="triggerContentWrapper">
           <label class="label" id="triggerLabel">
             <slot name="label"></slot>
           </label>
-          <div class="triggerContent" chevron=${this.chevron} aria-labelledby="triggerLabel">
+          <div class="triggerContent" chevron=${this.chevron}>
             <slot
               name="trigger"
               @slotchange="${this.handleTriggerTabIndex()}"></slot>

--- a/test/auro-dropdown.test.js
+++ b/test/auro-dropdown.test.js
@@ -71,8 +71,9 @@ describe('auro-dropdown', () => {
       </auro-dropdown>
     `);
 
-    const triggerEl = el.shadowRoot.querySelector('.triggerContent');
+    const triggerEl = el.shadowRoot.querySelector('.trigger');
     expect(triggerEl).to.have.attribute('aria-labelledby', 'triggerLabel');
+    expect(triggerEl).to.have.attribute('aria-controls', 'popover');
   })
 
   it('auro-dropdown shows only with click', async () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

- `aria-expanded="[true/false]"` attribute moved from `<auro-dropdown>` parent element to `<div id="trigger">` button element
- `aria-labelledby="triggerLabel"` attribute moved from `<div class="triggerContent">` to `<div id="trigger">` button element
- `aria-controls="popover"` attribute added to `<div id="trigger">` button element

**Fixes:** #133 

## Summary:

The auro-dropdown component by itself, when not used as part of [auro-select](https://github.com/AlaskaAirlines/auro-select) or [auro-combobox](https://github.com/AlaskaAirlines/auro-combobox), seems to most closely match the "Disclosure Widget" pattern as described in the [WAI-ARIA Authoring Practices document](https://w3c.github.io/aria-practices/#disclosure). 

Disclosure Widget examples:
- [W3C](https://w3c.github.io/aria-practices/examples/disclosure/disclosure-faq.html)
- [Adrian Roselli](https://adrianroselli.com/2020/05/disclosure-widgets.html)

Based on this pattern, I think it is best to place the [`aria-expanded`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) and [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attributes directly on the trigger button element. Additionally, I have added an [`aria-controls`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) attribute that references the popover element containing the dropdown's content.

This change resolves all [Axe](https://www.deque.com/axe/devtools/) [`aria-allowed-attr`](https://dequeuniversity.com/rules/axe/4.1/aria-allowed-attr) rule violations for auro-dropdown when it is used with the label content slot. It also resolves all `aria-allowed-attr` violations for auro-select and auro-combobox, which consume auro-dropdown.

Axe continues to flag `aria-allowed-attr` rule violations in auro-dropdown when `aria-label` or `aria-labelledby` attributes are applied directly onto `<auro-dropdown>`, since `<auro-dropdown>` has no `role` attribute. Based on this finding, we may want to remove those use case examples from the docs and specify that auro-dropdown should only be used with the label content slot in order to remain accessible.

## Type of change:

Please delete options that are not relevant.

- [X] Revision of an existing capability

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**